### PR TITLE
Bare minimum package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "state-svg-defs",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
The bare minimum for a package.json to allow installs through npm
(installation works fine through yarn add)

Fixes #1 